### PR TITLE
Add job queue manager

### DIFF
--- a/lib/job.rb
+++ b/lib/job.rb
@@ -1,0 +1,9 @@
+class Job
+  attr_reader :name, :dependency
+
+  def initialize(name, dependency=nil)
+    @name = name
+    @dependency = dependency
+    raise ArgumentError, "Jobs can't depend on themselves" if name == dependency
+  end
+end

--- a/lib/job_queue_manager.rb
+++ b/lib/job_queue_manager.rb
@@ -17,6 +17,7 @@ class JobQueueManager
   end
 
   def sort_jobs_queue!
+    raise RuntimeError, "Jobs can't have circular dependencies" if has_cyclic_dependency?
     jobs_queue.values.inject([]) { |sorted_jobs, job|
       sorted_jobs << job.name unless sorted_jobs.include?(job.name)
       if job.dependency
@@ -25,5 +26,16 @@ class JobQueueManager
       end
       sorted_jobs
     }
+  end
+
+  def has_cyclic_dependency?
+    jobs_queue.each { |job_name, job|
+      dependencies = []
+      while(job = jobs_queue[job.dependency])
+        return true if dependencies.include?(job.name)
+        dependencies << job.name
+      end
+    }
+    return false
   end
 end

--- a/lib/job_queue_manager.rb
+++ b/lib/job_queue_manager.rb
@@ -1,0 +1,29 @@
+class JobQueueManager
+  attr_reader :jobs_queue
+
+  def initialize(jobs_queue)
+    @jobs_queue = jobs_queue
+  end
+
+  def process_jobs_queue
+    parse_jobs_queue
+    sort_jobs_queue!
+  end
+
+  private
+
+  def parse_jobs_queue
+    @jobs_queue = JobQueueParser.new(jobs_queue).parse
+  end
+
+  def sort_jobs_queue!
+    jobs_queue.values.inject([]) { |sorted_jobs, job|
+      sorted_jobs << job.name unless sorted_jobs.include?(job.name)
+      if job.dependency
+        sorted_jobs.delete(job.dependency)
+        sorted_jobs.insert(sorted_jobs.index(job.name), job.dependency)
+      end
+      sorted_jobs
+    }
+  end
+end

--- a/lib/jobs_queue_parser.rb
+++ b/lib/jobs_queue_parser.rb
@@ -1,0 +1,15 @@
+class JobQueueParser
+  attr_reader :jobs_queue
+
+  def initialize(jobs_queue)
+    @jobs_queue = jobs_queue
+  end
+
+  def parse
+    jobs_queue.split("\n").inject({}){ |parsed_jobs, job|
+      job = Job.new(*job.split('=>').map(&:strip).reject(&:empty?))
+      parsed_jobs[job.name] = job
+      parsed_jobs
+    }
+  end
+end

--- a/spec/job_queue_manager_spec.rb
+++ b/spec/job_queue_manager_spec.rb
@@ -1,0 +1,63 @@
+describe JobQueueManager do
+  context "no jobs passed" do
+    it "returns an empty array" do
+      expect(described_class.new("").process_jobs_queue).to eq([])
+    end
+  end
+
+  context "single job passed" do
+    it "returns the single job" do
+      expect(described_class.new("a =>").process_jobs_queue).to eq(["a"])
+    end
+  end
+
+  context "multiple jobs passed" do
+    context "no dependency" do
+      let(:jobs) { "a =>
+                    b =>
+                    c =>" }
+
+      it "returns abc" do
+        expect(described_class.new(jobs).process_jobs_queue).to eq(["a", "b", "c"])
+      end
+    end
+
+    context "single dependency" do
+      let(:jobs) { "a =>
+                    b => c
+                    c =>" }
+
+      it "returns acb" do
+        expect(described_class.new(jobs).process_jobs_queue).to eq(["a", "c", "b"])
+      end
+    end
+
+    context "multiple dependencies" do
+      let(:jobs) { "a =>
+                    b => c
+                    c => f
+                    d => a
+                    e => b
+                    f =>" }
+
+      it "returns fcadbe" do
+       expect(described_class.new(jobs).process_jobs_queue).to eq(["f", "c", "a", "d", "b", "e"])
+      end
+    end
+  end
+
+  context "circular dependency passed" do
+    let(:jobs) { "a =>
+                  b => c
+                  c => f
+                  d => a
+                  e =>
+                  f => b" }
+
+    it "raises an error" do
+      expect {
+        described_class.new(jobs).process_jobs_queue
+      }.to raise_error(RuntimeError, "Jobs can't have circular dependencies")
+    end
+  end
+end

--- a/spec/job_queue_parser_spec.rb
+++ b/spec/job_queue_parser_spec.rb
@@ -1,0 +1,43 @@
+describe JobQueueParser do
+  context "single job" do
+    let(:parsed_job) { described_class.new("a => b").parse }
+
+    it "indexes the job hash by job name" do
+      expect(parsed_job.keys).to include("a")
+    end
+
+    it "creates the correct number of jobs" do
+      expect(parsed_job.keys.size).to eq(1)
+    end
+
+    it "stores Job objects in the job hash" do
+      expect(parsed_job["a"]).to be_an_instance_of(Job)
+    end
+
+    it "sets the correct job name" do
+      expect(parsed_job["a"].name).to eq("a")
+    end
+
+    it "sets the correct job dependency" do
+      expect(parsed_job["a"].dependency).to eq("b")
+    end
+  end
+
+  context "multiple jobs" do
+    let(:parsed_jobs) { described_class.new("a => b
+                                             b =>
+                                             c =>").parse }
+
+    it "creates the correct number of jobs" do
+      expect(parsed_jobs.keys.size).to eq(3)
+    end
+
+    it "parses the jobs correctly" do
+      expect(parsed_jobs.values.map(&:name)).to eq(["a", "b", "c"])
+    end
+
+    it "sets the correct job dependency" do
+      expect(parsed_jobs["a"].dependency).to eq("b")
+    end
+  end
+end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,0 +1,31 @@
+describe Job do
+  it "requires name" do
+    expect{
+      described_class.new
+    }.to raise_error(ArgumentError)
+  end
+
+  it "sets the correct job name" do
+    expect(described_class.new("a").name).to eq("a")
+  end
+
+  context "job name is equals job dependency" do
+    it "raises an error" do
+      expect{
+        described_class.new("a", "a")
+      }.to raise_error(ArgumentError, "Jobs can't depend on themselves")
+    end
+  end
+
+  context "with no dependency" do
+    it "sets nil for job dependency" do
+      expect(described_class.new("a").dependency).to be_nil
+    end
+  end
+
+  context "with a dependency" do
+    it "sets the correct job dependency" do
+      expect(described_class.new("a", "b").dependency).to eq("b")
+    end
+  end
+end


### PR DESCRIPTION
Hi Paul,

My first task was to create a Rspec test to 'translate' the coding exercise pdf requirements in tests.. so I've created a job_queue_manager spec file.

Of course all tests broken in the first place.. but I realised I'd need a job class to represent a Job and as a good practice.. a parser or a module just to parse the input jobs queue string. Then, I've create a Job class along with its tests and a Job Queue Parsers to receive a jobs queue string and to return a hash of jobs, each one with its name and dependency.

After getting the jobs queue correctly parsed and with the jobs inside the hash.. it was time to create the main class, Job Queue Manager. The job queue manager job has a task to receive the jobs queue string, send it to the parser, which will return the hash of jobs for the manager which will sort the jobs hash and finally format the response. As a last tweak, I've added a checker to check if there's circular dependency in the jobs queue and raise an error if exists.

Used TDD in the most of the coding exercise as well.

Cheers

Leandro.